### PR TITLE
Handle the possibility of f64::NAN being a negative NaN

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1121,13 +1121,13 @@ impl<'a> Deserializer<'a> {
             })
         } else if s == "nan" {
             Ok(Value {
-                e: E::Float(f64::NAN),
+                e: E::Float(f64::NAN.copysign(1.0)),
                 start,
                 end,
             })
         } else if s == "-nan" {
             Ok(Value {
-                e: E::Float(-f64::NAN),
+                e: E::Float(f64::NAN.copysign(-1.0)),
                 start,
                 end,
             })


### PR DESCRIPTION
I learned in https://github.com/rust-lang/miri/issues/3139 that the sign of f64::NAN is not specified.