### PR TITLE
Always serialize NaN without sign

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -288,8 +288,7 @@ macro_rules! serialize_float {
     ($this:expr, $v:expr) => {{
         $this.emit_key(ArrayState::Started)?;
         match ($v.is_sign_negative(), $v.is_nan(), $v == 0.0) {
-            (true, true, _) => write!($this.dst, "-nan"),
-            (false, true, _) => write!($this.dst, "nan"),
+            (_, true, _) => write!($this.dst, "nan"),
             (true, false, true) => write!($this.dst, "-0.0"),
             (false, false, true) => write!($this.dst, "0.0"),
             (_, false, false) => write!($this.dst, "{}", $v).and_then(|()| {

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -48,7 +48,7 @@ macro_rules! float_inf_tests {
         assert!(inf.sf5.is_nan());
         assert!(inf.sf5.is_sign_positive());
         assert!(inf.sf6.is_nan());
-        assert!(inf.sf6.is_sign_negative());
+        assert!(inf.sf6.is_sign_negative()); // NOTE: but serializes to just `nan`
 
         assert_eq!(inf.sf7, 0.0);
         assert!(inf.sf7.is_sign_positive());
@@ -64,7 +64,7 @@ sf2 = inf
 sf3 = -inf
 sf4 = nan
 sf5 = nan
-sf6 = -nan
+sf6 = nan
 sf7 = 0.0
 sf8 = -0.0
 "


### PR DESCRIPTION
In all likelihood, the sign of NaNs is not meaningful in the user's program. https://github.com/rust-lang/rfcs/pull/3514#issuecomment-1781873993: _"by and large nobody cares about the sign of a NaN"_. It would usually just be surprising and undesirable for `-nan` to appear in output serialized by this crate, when the sign of the NaN was not intentionally controlled by the caller, or may even be nondeterministic if it comes from arithmetic operations or a cast.

In https://github.com/toml-lang/toml/pull/506#discussion_r153486027 it sounds like the motivation for TOML supporting `-nan` was a Robustness Principle "be liberal in what you accept from others" without the intention that TOML emitters would ever produce it.

This crate will continue to **deserialize** `-nan` as a negative NaN.